### PR TITLE
Add Intel's SHA intrinsics (stubs + implemented SHA256 intrinsics)

### DIFF
--- a/source/inteli/internals.d
+++ b/source/inteli/internals.d
@@ -28,6 +28,7 @@ version(GNU)
         enum GDC_with_SSE2 = false;
         enum GDC_with_SSE3 = false;
         enum GDC_with_SSSE3 = false;
+        enum GDC_with_SHA = false;
     }
     else version (X86_64)
     {
@@ -48,6 +49,7 @@ version(GNU)
         enum GDC_with_SSE2 = true; // We don't have a way to detect that at CT, but we assume it's there
         enum GDC_with_SSE3 = false; // TODO: we don't have a way to detect that at CT
         enum GDC_with_SSSE3 = false; // TODO: we don't have a way to detect that at CT
+        enum GDC_with_SHA = false;
     }
     else
     {
@@ -57,6 +59,7 @@ version(GNU)
         enum GDC_with_SSE2 = false;
         enum GDC_with_SSE3 = false;
         enum GDC_with_SSSE3 = false;
+        enum GDC_with_SHA = false;
     }
 }
 else
@@ -67,6 +70,7 @@ else
     enum GDC_with_SSE2 = false;
     enum GDC_with_SSE3 = false;
     enum GDC_with_SSSE3 = false;
+    enum GDC_with_SHA = false;
 }
 
 version(LDC)
@@ -103,6 +107,7 @@ version(LDC)
         enum LDC_with_SSE42 = false;
         enum LDC_with_AVX = false;
         enum LDC_with_AVX2 = false;
+        enum LDC_with_SHA = false;
     }
     else version(AArch64)
     {
@@ -116,6 +121,7 @@ version(LDC)
         enum LDC_with_SSE42 = false;
         enum LDC_with_AVX = false;
         enum LDC_with_AVX2 = false;
+        enum LDC_with_SHA = false;
     }
     else
     {
@@ -130,6 +136,7 @@ version(LDC)
         enum LDC_with_SSE42 = __traits(targetHasFeature, "sse4.2");
         enum LDC_with_AVX = __traits(targetHasFeature, "avx");
         enum LDC_with_AVX2 = __traits(targetHasFeature, "avx2");
+        enum LDC_with_SHA = __traits(targetHasFeature, "sha");
     }
 }
 else
@@ -144,6 +151,7 @@ else
     enum LDC_with_SSE42 = false;
     enum LDC_with_AVX = false;
     enum LDC_with_AVX2 = false;
+    enum LDC_with_SHA = false;
 }
 
 enum LDC_with_ARM = LDC_with_ARM32 | LDC_with_ARM64;

--- a/source/inteli/package.d
+++ b/source/inteli/package.d
@@ -13,6 +13,7 @@ public import inteli.xmmintrin;
 public import inteli.pmmintrin;
 public import inteli.tmmintrin;
 public import inteli.smmintrin;
+public import inteli.shaintrin;
 
 public import inteli.math;
 

--- a/source/inteli/shaintrin.d
+++ b/source/inteli/shaintrin.d
@@ -1,0 +1,241 @@
+/**
+* SHA intrinsics.
+*
+* Copyright: Guillaume Piolat 2021.
+*            Johan Engelen 2021.
+* License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+*/
+module inteli.shaintrin;
+
+// SHA instructions
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#othertechs=SHA
+// Note: this header will work whether you have SHA enabled or not.
+// With LDC, use "dflags-ldc": ["-mattr=+sha"] or equivalent to actively
+// generate SHA instructions.
+
+public import inteli.types;
+import inteli.internals;
+
+static if (LDC_with_SHA)
+{
+    import ldc.gccbuiltins_x86;
+
+    private enum SHA_builtins = true;
+}
+else static if (GDC_with_SHA)
+{
+    import gcc.builtins;
+
+    private enum SHA_builtins = true;
+}
+else
+{
+    private enum SHA_builtins = false;
+}
+
+nothrow @nogc:
+
+/+
+/// Perform an intermediate calculation for the next four SHA1 message values (unsigned 32-bit integers) using previous message values from a and b, and store the result in dst.
+__m128i _mm_sha1nexte_epu32(__m128i a, __m128i b) @trusted
+{
+    static if (SHA_builtins)
+    {
+        return __builtin_ia32_sha1nexte(cast(int4) a, cast(int4) b);
+    }
+    else
+    {
+        assert(0);
+    }
+}
+unittest
+{
+}
++/
+
+/+
+/// Perform the final calculation for the next four SHA1 message values (unsigned 32-bit integers) using the intermediate result in a and the previous message values in b, and store the result in dst.
+__m128i _mm_sha1msg1_epu32(__m128i a, __m128i b) @trusted
+{
+    static if (SHA_builtins)
+    {
+        return __builtin_ia32_sha1msg1(cast(int4) a, cast(int4) b);
+    }
+    else
+    {
+        assert(0);
+    }
+}
+unittest
+{
+}
++/
+
+/+
+/// Calculate SHA1 state variable E after four rounds of operation from the current SHA1 state variable a, add that value to the scheduled values (unsigned 32-bit integers) in b, and store the result in dst.
+__m128i _mm_sha1msg2_epu32(__m128i a, __m128i b) @trusted
+{
+    static if (SHA_builtins)
+    {
+        return __builtin_ia32_sha1msg2(cast(int4) a, cast(int4) b);
+    }
+    else
+    {
+        assert(0);
+    }
+}
+unittest
+{
+}
++/
+
+/+
+/// Perform four rounds of SHA1 operation using an initial SHA1 state (A,B,C,D) from a and some pre-computed sum of the next 4 round message values (unsigned 32-bit integers), and state variable E from b, and store the updated SHA1 state (A,B,C,D) in dst. func contains the logic functions and round constants.
+__m128i _mm_sha1rnds4_epu32(__m128i a, __m128i b, const int func) @trusted
+{
+    static if (SHA_builtins)
+    {
+        return __builtin_ia32_sha1rnds4(cast(int4) a, cast(int4) b, func);
+    }
+    else
+    {
+        assert(0);
+    }
+
+}
++/
+
+/// Perform the final calculation for the next four SHA256 message values (unsigned 32-bit integers) using previous message values from `a` and `b`, and return the result.
+__m128i _mm_sha256msg1_epu32(__m128i a, __m128i b) @trusted
+{
+    static if (SHA_builtins)
+    {
+        return __builtin_ia32_sha256msg1(cast(int4) a, cast(int4) b);
+    }
+    else
+    {
+        import core.bitop : ror;
+        static uint sigma0(uint x) { return ror(x, 7) ^ ror(x, 18) ^ x >> 3; }
+
+        int4 dst;
+        int4 a4 = cast(int4) a;
+        int4 b4 = cast(int4) b;
+        uint W4 = b4.array[0];
+        uint W3 = a4.array[3];
+        uint W2 = a4.array[2];
+        uint W1 = a4.array[1];
+        uint W0 = a4.array[0];
+        dst.array[3] = W3 + sigma0(W4);
+        dst.array[2] = W2 + sigma0(W3);
+        dst.array[1] = W1 + sigma0(W2);
+        dst.array[0] = W0 + sigma0(W1);
+        return cast(__m128i) dst;
+    }
+}
+unittest
+{
+    __m128i a = [15, 20, 130, 12345];
+    __m128i b = [15, 20, 130, 12345];
+    __m128i result = _mm_sha256msg1_epu32(a, b);
+    assert(result.array == [671416337, 69238821, 2114864873, 503574586]);
+}
+
+/// Perform 2 rounds of SHA256 operation using an initial SHA256 state (C,D,G,H) from `a`, an initial SHA256 state (A,B,E,F) from `b`, and a pre-computed sum of the next 2 round message values (unsigned 32-bit integers) and the corresponding round constants from k, and return the updated SHA256 state (A,B,E,F).
+__m128i _mm_sha256msg2_epu32(__m128i a, __m128i b) @trusted
+{
+    static if (SHA_builtins)
+    {
+        return __builtin_ia32_sha256msg2(cast(int4) a, cast(int4) b);
+    }
+    else
+    {
+        import core.bitop : ror;
+        static uint sigma1(uint x) { return ror(x, 17) ^ ror(x, 19) ^ x >> 10; }
+
+        int4 dst;
+        int4 a4 = cast(int4) a;
+        int4 b4 = cast(int4) b;
+        uint W14 = b4.array[2];
+        uint W15 = b4.array[3];
+        uint W16 = a4.array[0] + sigma1(W14);
+        uint W17 = a4.array[1] + sigma1(W15);
+        uint W18 = a4.array[2] + sigma1(W16);
+        uint W19 = a4.array[3] + sigma1(W17);
+        dst.array[3] = W19;
+        dst.array[2] = W18;
+        dst.array[1] = W17;
+        dst.array[0] = W16;
+        return cast(__m128i) dst;
+    }
+}
+unittest
+{
+    __m128i a = [15, 20, 130, 12345];
+    __m128i b = [15, 20, 130, 12345];
+    __m128i result = _mm_sha256msg2_epu32(a, b);
+    assert(result.array == [5324815, 505126944, -2012842764, -1542210977]);
+}
+
+/// Perform an intermediate calculation for the next four SHA256 message values (unsigned 32-bit integers) using previous message values from `a` and `b`, and return the result.
+__m128i _mm_sha256rnds2_epu32(__m128i a, __m128i b, __m128i k) @trusted
+{
+    static if (SHA_builtins)
+    {
+        return __builtin_ia32_sha256rnds2(cast(int4) a, cast(int4) b, cast(int4) k);
+    }
+    else
+    {
+        import core.bitop : ror;
+        static uint Ch(uint x, uint y, uint z) { return z ^ (x & (y ^ z)); }
+        static uint Maj(uint x, uint y, uint z) { return (x & y) | (z & (x ^ y)); }
+        static uint sum0(uint x) { return ror(x, 2) ^ ror(x, 13) ^ ror(x, 22); }
+        static uint sum1(uint x) { return ror(x, 6) ^ ror(x, 11) ^ ror(x, 25); }
+
+        int4 dst;
+        int4 a4 = cast(int4) a;
+        int4 b4 = cast(int4) b;
+        int4 k4 = cast(int4) k;
+
+        const A0 = b4.array[3];
+        const B0 = b4.array[2];
+        const C0 = a4.array[3];
+        const D0 = a4.array[2];
+        const E0 = b4.array[1];
+        const F0 = b4.array[0];
+        const G0 = a4.array[1];
+        const H0 = a4.array[0];
+        const W_K0 = k4.array[0];
+        const W_K1 = k4.array[1];
+        const A1 = Ch(E0, F0, G0) + sum1(E0) + W_K0 + H0 + Maj(A0, B0, C0) + sum0(A0);
+        const B1 = A0;
+        const C1 = B0;
+        const D1 = C0;
+        const E1 = Ch(E0, F0, G0) + sum1(E0) + W_K0 + H0 + D0;
+        const F1 = E0;
+        const G1 = F0;
+        const H1 = G0;
+        const A2 = Ch(E1, F1, G1) + sum1(E1) + W_K1 + H1 + Maj(A1, B1, C1) + sum0(A1);
+        const B2 = A1;
+        const C2 = B1;
+        const D2 = C1;
+        const E2 = Ch(E1, F1, G1) + sum1(E1) + W_K1 + H1 + D1;
+        const F2 = E1;
+        const G2 = F1;
+        const H2 = G1;
+
+        dst.array[3] = A2;
+        dst.array[2] = B2;
+        dst.array[1] = E2;
+        dst.array[0] = F2;
+
+        return cast(__m128i) dst;
+    }
+}
+unittest
+{
+    __m128i a = [15, 20, 130, 12345];
+    __m128i b = [15, 20, 130, 12345];
+    __m128i k = [15, 20, 130, 12345];
+    __m128i result = _mm_sha256rnds2_epu32(a, b, k);
+    assert(result.array == [1384123044, -2050674062, 327754346, 956342016]);
+}

--- a/source/inteli/shaintrin.d
+++ b/source/inteli/shaintrin.d
@@ -18,14 +18,10 @@ import inteli.internals;
 
 static if (LDC_with_SHA)
 {
-    import ldc.gccbuiltins_x86;
-
     private enum SHA_builtins = true;
 }
 else static if (GDC_with_SHA)
 {
-    import gcc.builtins;
-
     private enum SHA_builtins = true;
 }
 else
@@ -125,10 +121,10 @@ __m128i _mm_sha256msg1_epu32(__m128i a, __m128i b) @trusted
         uint W2 = a4.array[2];
         uint W1 = a4.array[1];
         uint W0 = a4.array[0];
-        dst.array[3] = W3 + sigma0(W4);
-        dst.array[2] = W2 + sigma0(W3);
-        dst.array[1] = W1 + sigma0(W2);
-        dst.array[0] = W0 + sigma0(W1);
+        dst.ptr[3] = W3 + sigma0(W4);
+        dst.ptr[2] = W2 + sigma0(W3);
+        dst.ptr[1] = W1 + sigma0(W2);
+        dst.ptr[0] = W0 + sigma0(W1);
         return cast(__m128i) dst;
     }
 }
@@ -161,10 +157,10 @@ __m128i _mm_sha256msg2_epu32(__m128i a, __m128i b) @trusted
         uint W17 = a4.array[1] + sigma1(W15);
         uint W18 = a4.array[2] + sigma1(W16);
         uint W19 = a4.array[3] + sigma1(W17);
-        dst.array[3] = W19;
-        dst.array[2] = W18;
-        dst.array[1] = W17;
-        dst.array[0] = W16;
+        dst.ptr[3] = W19;
+        dst.ptr[2] = W18;
+        dst.ptr[1] = W17;
+        dst.ptr[0] = W16;
         return cast(__m128i) dst;
     }
 }
@@ -223,10 +219,10 @@ __m128i _mm_sha256rnds2_epu32(__m128i a, __m128i b, __m128i k) @trusted
         const G2 = F1;
         const H2 = G1;
 
-        dst.array[3] = A2;
-        dst.array[2] = B2;
-        dst.array[1] = E2;
-        dst.array[0] = F2;
+        dst.ptr[3] = A2;
+        dst.ptr[2] = B2;
+        dst.ptr[1] = E2;
+        dst.ptr[0] = F2;
 
         return cast(__m128i) dst;
     }


### PR DESCRIPTION
It was fun to implement these :)   The instruction algorithms given by Intel are implemented almost verbatim.

For the unittests, I used the outcome of the implemented algorithm as the "correct" output, because I don't have a CPU that has these instructions. In other words: the values in the unittest are obtained from the code in the PR and will be incorrect if the implementation is incorrect. @p0nce Can you check on your machine that the actual SHA machine instructions indeed give the same results?  Thanks!