### PR TITLE
Add a few AVX and AVX2 intrinsics

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,14 +9,14 @@
     "buildTypes": {
         "unittest-inst": {
             "buildOptions": ["unittests", "debugMode", "debugInfo"],
-            "dflags-ldc": ["-mattr=+sse3,ssse3,sse4.2"]
+            "dflags-ldc": ["-mattr=+sse3,ssse3,sse4.2,avx,avx2"]
         },
         "unittest-release": {
             "buildOptions": ["unittests", "optimize", "inline"]
         },
         "unittest-release-inst": {
             "buildOptions": ["unittests", "optimize", "inline"],
-            "dflags-ldc": ["-mattr=+sse3,ssse3,sse4.2"]
+            "dflags-ldc": ["-mattr=+sse3,ssse3,sse4.2,avx,avx2"]
         },
         "unittest-arm32": {
             "buildOptions": ["unittests", "debugMode", "debugInfo"],

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -141,7 +141,7 @@ __m256i _mm256_madd_epi16 (__m256i a, __m256i b) pure @trusted
         {
             r.ptr[i] = sa.array[2*i] * sb.array[2*i] + sa.array[2*i+1] * sb.array[2*i+1];
         }
-        return r;
+        return cast(__m256i) r;
     }
 }
 unittest
@@ -358,9 +358,9 @@ __m256i _mm256_srli_epi32 (__m256i a, int imm8) pure @trusted
         //       D says "It's illegal to shift by the same or more bits
         //       than the size of the quantity being shifted"
         //       and it's UB instead.
-        int8 r = _mm256_setzero_si256();
+        int8 r = cast(int8) _mm256_setzero_si256();
         if (count >= 32)
-            return r;
+            return cast(__m256i) r;
         r.ptr[0] = a_int8.array[0] >>> count;
         r.ptr[1] = a_int8.array[1] >>> count;
         r.ptr[2] = a_int8.array[2] >>> count;

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -1,0 +1,391 @@
+/**
+* AVX2 intrinsics.
+* https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#techs=AVX2
+*
+* Copyright: Guillaume Piolat 2022.
+*            Johan Engelen 2022.
+* License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+*/
+module inteli.avx2intrin;
+
+// AVX2 instructions
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#techs=AVX2
+// Note: this header will work whether you have AVX2 enabled or not.
+// With LDC, use "dflags-ldc": ["-mattr=+avx2"] or equivalent to actively
+// generate AVX2 instructions.
+
+public import inteli.types;
+import inteli.internals;
+
+// Pull in all previous instruction set intrinsics.
+public import inteli.avxintrin;
+
+nothrow @nogc:
+
+/// Add packed 32-bit integers in `a` and `b`.
+__m256i _mm256_add_epi32(__m256i a, __m256i b) pure @safe
+{
+    pragma(inline, true);
+    return cast(__m256i)(cast(int8)a + cast(int8)b);
+}
+unittest
+{
+    __m256i A = _mm256_setr_epi32( -7, -1, 0, 9, -100, 100, 234, 432);
+    int8 R = _mm256_add_epi32(A, A);
+    int[8] correct = [ -14, -2, 0, 18, -200, 200, 468, 864 ];
+    assert(R.array == correct);
+}
+
+/// Compute the bitwise AND of 256 bits (representing integer data) in `a` and `b`.
+__m256i _mm256_and_si256 (__m256i a, __m256i b) pure @safe
+{
+    pragma(inline, true);
+    return a & b;
+}
+unittest
+{
+    __m256i A = _mm256_set1_epi32(7);
+    __m256i B = _mm256_set1_epi32(14);
+    __m256i R = _mm256_and_si256(A, B);
+    int[8] correct = [6, 6, 6, 6, 6, 6, 6, 6];
+    assert(R.array == correct);
+}
+
+/// Zero-extend packed unsigned 16-bit integers in `a` to packed 32-bit integers.
+__m256i _mm256_cvtepu16_epi32(__m128i a) pure @trusted
+{
+    static if (GDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_pmovzxwd256(cast(short8)a);
+    }
+    else
+    {
+        ushort8 usa = cast(ushort8)a;
+        uint8 r;
+        r.ptr[0] = usa.array[0];
+        r.ptr[1] = usa.array[1];
+        r.ptr[2] = usa.array[2];
+        r.ptr[3] = usa.array[3];
+        r.ptr[4] = usa.array[4];
+        r.ptr[5] = usa.array[5];
+        r.ptr[6] = usa.array[6];
+        r.ptr[7] = usa.array[7];
+        return cast(__m256i)r;
+    }
+}
+unittest
+{
+    __m128i A = _mm_setr_epi16(-1, 0, -32768, 32767, -1, 0, -32768, 32767);
+    int8 C = cast(int8) _mm256_cvtepu16_epi32(A);
+    int[8] correct = [65535, 0, 32768, 32767, 65535, 0, 32768, 32767];
+    assert(C.array == correct);
+}
+
+/// Extract 128 bits (composed of integer data) from `a`, selected with `imm8`.
+__m128i _mm256_extracti128_si256(int imm8)(__m256i a) pure @trusted
+    if ( (imm8 == 0) || (imm8 == 1) )
+{
+    pragma(inline, true);
+
+    static if (GDC_with_AVX2)
+    {
+        return cast(__m128i) __builtin_ia32_extract128i256(a, imm8);
+    }
+    else version (LDC)
+    {
+        enum str = (imm8 == 1) ? "<i32 2, i32 3>" : "<i32 0, i32 1>";
+        enum ir = "%r = shufflevector <4 x i64> %0, <4 x i64> undef, <2 x i32>" ~ str ~ "\n" ~
+                  "ret <2 x i64> %r";
+        return cast(__m128i) LDCInlineIR!(ir, ulong2, ulong4)(cast(ulong4)a);
+    }
+    else
+    {
+        ulong2 ret;
+        ret.ptr[0] = (imm8==1) ? a.array[2] : a.array[0];
+        ret.ptr[1] = (imm8==1) ? a.array[3] : a.array[1];
+        return cast(__m128i) ret;
+    }
+}
+unittest
+{
+    __m256i A = _mm256_setr_epi32( -7, -1, 0, 9, -100, 100, 234, 432 );
+    int[4] correct0 = [ -100, 100, 234, 432 ];
+    int[4] correct1 = [ -7, -1, 0, 9 ];
+    __m128i R0 = _mm256_extracti128_si256!(0)(A);
+    __m128i R1 = _mm256_extracti128_si256!(1)(A);
+    assert(R0.array == correct0);
+    assert(R1.array == correct1);
+}
+
+/// Multiply packed signed 16-bit integers in `a` and `b`, producing intermediate
+/// signed 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit integers,
+/// and pack the results in destination.
+__m256i _mm256_madd_epi16 (__m256i a, __m256i b) pure @trusted
+{
+    static if (GDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_pmaddwd256(cast(short16)a, cast(short16)b);
+    }
+    else static if (LDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_pmaddwd256(cast(short16)a, cast(short16)b);
+    }
+    else
+    {
+        short16 sa = cast(short16)a;
+        short16 sb = cast(short16)b;
+        int8 r;
+        foreach(i; 0..8)
+        {
+            r.ptr[i] = sa.array[2*i] * sb.array[2*i] + sa.array[2*i+1] * sb.array[2*i+1];
+        }
+        return r;
+    }
+}
+unittest
+{
+    short16 A = [0, 1, 2, 3, -32768, -32768, 32767, 32767, 0, 1, 2, 3, -32768, -32768, 32767, 32767];
+    short16 B = [0, 1, 2, 3, -32768, -32768, 32767, 32767, 0, 1, 2, 3, -32768, -32768, 32767, 32767];
+    int8 R = _mm256_madd_epi16(cast(__m256i)A, cast(__m256i)B);
+    int[8] correct = [1, 13, -2147483648, 2*32767*32767, 1, 13, -2147483648, 2*32767*32767];
+    assert(R.array == correct);
+}
+
+/// Compute the bitwise OR of 256 bits (representing integer data) in `a` and `b`.
+__m256i _mm256_or_si256 (__m256i a, __m256i b) pure @safe
+{
+    return a | b;
+}
+// TODO unittest and thus force inline
+
+/// Compute the absolute differences of packed unsigned 8-bit integers in `a` and `b`, then horizontally sum each
+/// consecutive 8 differences to produce two unsigned 16-bit integers, and pack these unsigned 16-bit integers in the
+/// low 16 bits of 64-bit elements in result.
+__m256i _mm256_sad_epu8 (__m256i a, __m256i b) pure @trusted
+{
+    static if (GDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_psadbw256(cast(ubyte32)a, cast(ubyte32)b);
+    }
+    else static if (LDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_psadbw256(cast(byte32)a, cast(byte32)b);
+    }
+    else
+    {
+        // PERF: ARM64/32 is lacking
+        byte32 ab = cast(byte32)a;
+        byte32 bb = cast(byte32)b;
+        ubyte[32] t;
+        foreach(i; 0..32)
+        {
+            int diff = cast(ubyte)(ab.array[i]) - cast(ubyte)(bb.array[i]);
+            if (diff < 0) diff = -diff;
+            t[i] = cast(ubyte)(diff);
+        }
+        int8 r = _mm256_setzero_si256();
+        r.ptr[0] = t[0]  + t[1]  + t[2]  + t[3]  + t[4]  + t[5]  + t[6]  + t[7];
+        r.ptr[2] = t[8]  + t[9]  + t[10] + t[11] + t[12] + t[13] + t[14] + t[15];
+        r.ptr[4] = t[16] + t[17] + t[18] + t[19] + t[20] + t[21] + t[22] + t[23];
+        r.ptr[6] = t[24] + t[25] + t[26] + t[27] + t[28] + t[29] + t[30] + t[31];
+        return r;
+    }
+}
+unittest
+{
+    __m256i A = _mm256_setr_epi8(3, 4, 6, 8, 12, 14, 18, 20, 24, 30, 32, 38, 42, 44, 48, 54,
+                              3, 4, 6, 8, 12, 14, 18, 20, 24, 30, 32, 38, 42, 44, 48, 54); // primes + 1
+    __m256i B = _mm256_set1_epi8(1);
+    __m256i R = _mm256_sad_epu8(A, B);
+    int[8] correct = [2 + 3 + 5 + 7 + 11 + 13 + 17 + 19,
+                      0,
+                      23 + 29 + 31 + 37 + 41 + 43 + 47 + 53,
+                      0,
+                      2 + 3 + 5 + 7 + 11 + 13 + 17 + 19,
+                      0,
+                      23 + 29 + 31 + 37 + 41 + 43 + 47 + 53,
+                      0];
+    assert(R.array == correct);
+}
+
+/// Shift packed 16-bit integers in `a` left by `imm8` while shifting in zeros.
+__m256i _mm256_slli_epi16(__m256i a, int imm8) pure @trusted
+{
+    static if (GDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_psllwi256(cast(short16)a, cast(ubyte)imm8);
+    }
+    else static if (LDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_psllwi256(cast(short16)a, cast(ubyte)imm8);
+    }
+    else
+    {
+        //PERF: ARM
+        short16 sa  = cast(short16)a;
+        short16 r   = cast(short16)_mm256_setzero_si256();
+        ubyte count = cast(ubyte) imm8;
+        if (count > 15)
+            return cast(__m256i)r;
+        foreach(i; 0..16)
+            r.ptr[i] = cast(short)(sa.array[i] << count);
+        return cast(__m256i)r;
+    }
+}
+unittest
+{
+    __m256i A = _mm256_setr_epi16(0, 1, 2, 3, -4, -5, 6, 7, 0, 1, 2, 3, -4, -5, 6, 7);
+    short16 B = cast(short16)( _mm256_slli_epi16(A, 1) );
+    short16 B2 = cast(short16)( _mm256_slli_epi16(A, 1 + 256) );
+    short[8] expectedB = [ 0, 2, 4, 6, -8, -10, 12, 14, 0, 2, 4, 6, -8, -10, 12, 14 ];
+    assert(B.array == expectedB);
+    assert(B2.array == expectedB);
+
+    short16 C = cast(short16)( _mm256_slli_epi16(A, 16) );
+    short[8] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
+    assert(C.array == expectedC);
+}
+
+/// Shift packed 32-bit integers in `a` left by `imm8` while shifting in zeros.
+__m256i _mm256_slli_epi32 (__m256i a, int imm8) pure @trusted
+{
+    static if (GDC_with_AVX2)
+    {
+        return __builtin_ia32_pslldi256(a, cast(ubyte)imm8);
+    }
+    else static if (LDC_with_AVX2)
+    {
+        return __builtin_ia32_pslldi256(a, cast(ubyte)imm8);
+    }
+    else
+    {
+        // Note: the intrinsics guarantee imm8[0..7] is taken, however
+        //       D says "It's illegal to shift by the same or more bits
+        //       than the size of the quantity being shifted"
+        //       and it's UB instead.
+        int8 r = _mm256_setzero_si256();
+
+        ubyte count = cast(ubyte) imm8;
+        if (count > 31)
+            return r;
+
+        foreach(i; 0..8)
+            r.array[i] = cast(uint)(a.array[i]) << count;
+        return r;
+    }
+}
+unittest
+{
+    __m256i A = _mm256_setr_epi32(0, 2, 3, -4, 0, 2, 3, -4);
+    __m256i B = _mm256_slli_epi32(A, 1);
+    __m256i B2 = _mm256_slli_epi32(A, 1 + 256);
+    int[8] expectedB = [ 0, 4, 6, -8, 0, 4, 6, -8 ];
+    assert(B.array == expectedB);
+    assert(B2.array == expectedB);
+
+    __m256i C = _mm256_slli_epi32(A, 0);
+    int[8] expectedC = [ 0, 2, 3, -4, 0, 2, 3, -4 ];
+    assert(C.array == expectedC);
+
+    __m256i D = _mm256_slli_epi32(A, 65);
+    int[8] expectedD = [ 0, 0, 0, 0, 0, 0, 0, 0 ];
+    assert(D.array == expectedD);
+}
+
+/// Shift packed 16-bit integers in `a` right by `imm8` while shifting in zeros.
+__m256i _mm256_srli_epi16 (__m256i a, int imm8) pure @trusted
+{
+    static if (GDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_psrlwi256(cast(short16)a, cast(ubyte)imm8);
+    }
+    else static if (LDC_with_AVX2)
+    {
+        return cast(__m256i) __builtin_ia32_psrlwi256(cast(short16)a, cast(ubyte)imm8);
+    }
+    else
+    {
+        //PERF: ARM
+        short16 sa  = cast(short16)a;
+        ubyte count = cast(ubyte)imm8;
+        short16 r   = cast(short16) _mm256_setzero_si256();
+        if (count >= 16)
+            return cast(__m256i)r;
+
+        foreach(i; 0..16)
+            r.array[i] = cast(short)(cast(ushort)(sa.array[i]) >> count);
+        return cast(__m256i)r;
+    }
+}
+unittest
+{
+    __m256i A = _mm256_setr_epi16(0, 1, 2, 3, -4, -5, 6, 7, 0, 1, 2, 3, -4, -5, 6, 7);
+    short16 B = cast(short16)( _mm256_srli_epi16(A, 1) );
+    short16 B2 = cast(short16)( _mm256_srli_epi16(A, 1 + 256) );
+    short[16] expectedB = [ 0, 0, 1, 1, 0x7FFE, 0x7FFD, 3, 3, 0, 0, 1, 1, 0x7FFE, 0x7FFD, 3, 3 ];
+    assert(B.array == expectedB);
+    assert(B2.array == expectedB);
+
+    short16 C = cast(short16)( _mm256_srli_epi16(A, 16) );
+    short[16] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
+    assert(C.array == expectedC);
+
+    short16 D = cast(short16)( _mm256_srli_epi16(A, 0) );
+    short[16] expectedD = [ 0, 1, 2, 3, -4, -5, 6, 7, 0, 1, 2, 3, -4, -5, 6, 7 ];
+    assert(D.array == expectedD);
+}
+
+/// Shift packed 32-bit integers in `a` right by `imm8` while shifting in zeros.
+__m256i _mm256_srli_epi32 (__m256i a, int imm8) pure @trusted
+{
+    static if (GDC_with_AVX2)
+    {
+        return __builtin_ia32_psrldi256(a, cast(ubyte)imm8);
+    }
+    else static if (LDC_with_AVX2)
+    {
+        return __builtin_ia32_psrldi256(a, cast(ubyte)imm8);
+    }
+    else
+    {
+        ubyte count = cast(ubyte) imm8;
+
+        // Note: the intrinsics guarantee imm8[0..7] is taken, however
+        //       D says "It's illegal to shift by the same or more bits
+        //       than the size of the quantity being shifted"
+        //       and it's UB instead.
+        int8 r = _mm256_setzero_si256();
+        if (count >= 32)
+            return r;
+        r.ptr[0] = a.array[0] >>> count;
+        r.ptr[1] = a.array[1] >>> count;
+        r.ptr[2] = a.array[2] >>> count;
+        r.ptr[3] = a.array[3] >>> count;
+        r.ptr[4] = a.array[4] >>> count;
+        r.ptr[5] = a.array[5] >>> count;
+        r.ptr[6] = a.array[6] >>> count;
+        r.ptr[7] = a.array[7] >>> count;
+        return r;
+    }
+}
+unittest
+{
+    __m256i A = _mm256_setr_epi32(0, 2, 3, -4, 0, 2, 3, -4);
+    __m256i B = _mm256_srli_epi32(A, 1);
+    __m256i B2 = _mm256_srli_epi32(A, 1 + 256);
+    int[8] expectedB = [ 0, 1, 1, 0x7FFFFFFE, 0, 1, 1, 0x7FFFFFFE];
+    assert(B.array == expectedB);
+    assert(B2.array == expectedB);
+
+    __m256i C = _mm256_srli_epi32(A, 255);
+    int[8] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0 ];
+    assert(C.array == expectedC);
+}
+
+/// Compute the bitwise XOR of 256 bits (representing integer data) in `a` and `b`.
+__m256i _mm256_xor_si256 (__m256i a, __m256i b) pure @safe
+{
+    return a ^ b;
+}
+// TODO unittest and thus force inline
+

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -46,7 +46,7 @@ unittest
 {
     __m256i A = _mm256_set1_epi32(7);
     __m256i B = _mm256_set1_epi32(14);
-    __m256i R = _mm256_and_si256(A, B);
+    int8 R = _mm256_and_si256(A, B);
     int[8] correct = [6, 6, 6, 6, 6, 6, 6, 6];
     assert(R.array == correct);
 }
@@ -183,7 +183,7 @@ __m256i _mm256_sad_epu8 (__m256i a, __m256i b) pure @trusted
         {
             int diff = cast(ubyte)(ab.array[i]) - cast(ubyte)(bb.array[i]);
             if (diff < 0) diff = -diff;
-            t[i] = cast(ubyte)(diff);
+            t.ptr[i] = cast(ubyte)(diff);
         }
         int8 r = _mm256_setzero_si256();
         r.ptr[0] = t[0]  + t[1]  + t[2]  + t[3]  + t[4]  + t[5]  + t[6]  + t[7];
@@ -198,7 +198,7 @@ unittest
     __m256i A = _mm256_setr_epi8(3, 4, 6, 8, 12, 14, 18, 20, 24, 30, 32, 38, 42, 44, 48, 54,
                               3, 4, 6, 8, 12, 14, 18, 20, 24, 30, 32, 38, 42, 44, 48, 54); // primes + 1
     __m256i B = _mm256_set1_epi8(1);
-    __m256i R = _mm256_sad_epu8(A, B);
+    int8 R = _mm256_sad_epu8(A, B);
     int[8] correct = [2 + 3 + 5 + 7 + 11 + 13 + 17 + 19,
                       0,
                       23 + 29 + 31 + 37 + 41 + 43 + 47 + 53,
@@ -265,6 +265,7 @@ __m256i _mm256_slli_epi32 (__m256i a, int imm8) pure @trusted
         //       D says "It's illegal to shift by the same or more bits
         //       than the size of the quantity being shifted"
         //       and it's UB instead.
+        int8 a_int8 = cast(int8) a;
         int8 r = _mm256_setzero_si256();
 
         ubyte count = cast(ubyte) imm8;
@@ -272,24 +273,24 @@ __m256i _mm256_slli_epi32 (__m256i a, int imm8) pure @trusted
             return r;
 
         foreach(i; 0..8)
-            r.array[i] = cast(uint)(a.array[i]) << count;
+            r.ptr[i] = cast(uint)(a_int8.array[i]) << count;
         return r;
     }
 }
 unittest
 {
     __m256i A = _mm256_setr_epi32(0, 2, 3, -4, 0, 2, 3, -4);
-    __m256i B = _mm256_slli_epi32(A, 1);
-    __m256i B2 = _mm256_slli_epi32(A, 1 + 256);
+    int8 B = _mm256_slli_epi32(A, 1);
+    int8 B2 = _mm256_slli_epi32(A, 1 + 256);
     int[8] expectedB = [ 0, 4, 6, -8, 0, 4, 6, -8 ];
     assert(B.array == expectedB);
     assert(B2.array == expectedB);
 
-    __m256i C = _mm256_slli_epi32(A, 0);
+    int8 C = _mm256_slli_epi32(A, 0);
     int[8] expectedC = [ 0, 2, 3, -4, 0, 2, 3, -4 ];
     assert(C.array == expectedC);
 
-    __m256i D = _mm256_slli_epi32(A, 65);
+    int8 D = _mm256_slli_epi32(A, 65);
     int[8] expectedD = [ 0, 0, 0, 0, 0, 0, 0, 0 ];
     assert(D.array == expectedD);
 }
@@ -315,24 +316,24 @@ __m256i _mm256_srli_epi16 (__m256i a, int imm8) pure @trusted
             return cast(__m256i)r;
 
         foreach(i; 0..16)
-            r.array[i] = cast(short)(cast(ushort)(sa.array[i]) >> count);
+            r.ptr[i] = cast(short)(cast(ushort)(sa.array[i]) >> count);
         return cast(__m256i)r;
     }
 }
 unittest
 {
     __m256i A = _mm256_setr_epi16(0, 1, 2, 3, -4, -5, 6, 7, 0, 1, 2, 3, -4, -5, 6, 7);
-    short16 B = cast(short16)( _mm256_srli_epi16(A, 1) );
-    short16 B2 = cast(short16)( _mm256_srli_epi16(A, 1 + 256) );
+    short16 B = _mm256_srli_epi16(A, 1);
+    short16 B2 = _mm256_srli_epi16(A, 1 + 256);
     short[16] expectedB = [ 0, 0, 1, 1, 0x7FFE, 0x7FFD, 3, 3, 0, 0, 1, 1, 0x7FFE, 0x7FFD, 3, 3 ];
     assert(B.array == expectedB);
     assert(B2.array == expectedB);
 
-    short16 C = cast(short16)( _mm256_srli_epi16(A, 16) );
+    short16 C = _mm256_srli_epi16(A, 16);
     short[16] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
     assert(C.array == expectedC);
 
-    short16 D = cast(short16)( _mm256_srli_epi16(A, 0) );
+    short16 D = _mm256_srli_epi16(A, 0);
     short[16] expectedD = [ 0, 1, 2, 3, -4, -5, 6, 7, 0, 1, 2, 3, -4, -5, 6, 7 ];
     assert(D.array == expectedD);
 }
@@ -351,6 +352,7 @@ __m256i _mm256_srli_epi32 (__m256i a, int imm8) pure @trusted
     else
     {
         ubyte count = cast(ubyte) imm8;
+        int8 a_int8 = cast(int8) a;
 
         // Note: the intrinsics guarantee imm8[0..7] is taken, however
         //       D says "It's illegal to shift by the same or more bits
@@ -359,27 +361,27 @@ __m256i _mm256_srli_epi32 (__m256i a, int imm8) pure @trusted
         int8 r = _mm256_setzero_si256();
         if (count >= 32)
             return r;
-        r.ptr[0] = a.array[0] >>> count;
-        r.ptr[1] = a.array[1] >>> count;
-        r.ptr[2] = a.array[2] >>> count;
-        r.ptr[3] = a.array[3] >>> count;
-        r.ptr[4] = a.array[4] >>> count;
-        r.ptr[5] = a.array[5] >>> count;
-        r.ptr[6] = a.array[6] >>> count;
-        r.ptr[7] = a.array[7] >>> count;
+        r.ptr[0] = a_int8.array[0] >>> count;
+        r.ptr[1] = a_int8.array[1] >>> count;
+        r.ptr[2] = a_int8.array[2] >>> count;
+        r.ptr[3] = a_int8.array[3] >>> count;
+        r.ptr[4] = a_int8.array[4] >>> count;
+        r.ptr[5] = a_int8.array[5] >>> count;
+        r.ptr[6] = a_int8.array[6] >>> count;
+        r.ptr[7] = a_int8.array[7] >>> count;
         return r;
     }
 }
 unittest
 {
     __m256i A = _mm256_setr_epi32(0, 2, 3, -4, 0, 2, 3, -4);
-    __m256i B = _mm256_srli_epi32(A, 1);
-    __m256i B2 = _mm256_srli_epi32(A, 1 + 256);
+    int8 B = _mm256_srli_epi32(A, 1);
+    int8 B2 = _mm256_srli_epi32(A, 1 + 256);
     int[8] expectedB = [ 0, 1, 1, 0x7FFFFFFE, 0, 1, 1, 0x7FFFFFFE];
     assert(B.array == expectedB);
     assert(B2.array == expectedB);
 
-    __m256i C = _mm256_srli_epi32(A, 255);
+    int8 C = _mm256_srli_epi32(A, 255);
     int[8] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0 ];
     assert(C.array == expectedC);
 }

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -101,9 +101,10 @@ __m128i _mm256_extracti128_si256(int imm8)(__m256i a) pure @trusted
     }
     else
     {
+        long4 al = cast(long4) a;
         long2 ret;
-        ret.ptr[0] = (imm8==1) ? a.array[2] : a.array[0];
-        ret.ptr[1] = (imm8==1) ? a.array[3] : a.array[1];
+        ret.ptr[0] = (imm8==1) ? al.array[2] : al.array[0];
+        ret.ptr[1] = (imm8==1) ? al.array[3] : al.array[1];
         return cast(__m128i) ret;
     }
 }

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -185,12 +185,12 @@ __m256i _mm256_sad_epu8 (__m256i a, __m256i b) pure @trusted
             if (diff < 0) diff = -diff;
             t.ptr[i] = cast(ubyte)(diff);
         }
-        int8 r = _mm256_setzero_si256();
+        int8 r = cast(int8) _mm256_setzero_si256();
         r.ptr[0] = t[0]  + t[1]  + t[2]  + t[3]  + t[4]  + t[5]  + t[6]  + t[7];
         r.ptr[2] = t[8]  + t[9]  + t[10] + t[11] + t[12] + t[13] + t[14] + t[15];
         r.ptr[4] = t[16] + t[17] + t[18] + t[19] + t[20] + t[21] + t[22] + t[23];
         r.ptr[6] = t[24] + t[25] + t[26] + t[27] + t[28] + t[29] + t[30] + t[31];
-        return r;
+        return cast(__m256i) r;
     }
 }
 unittest
@@ -266,15 +266,15 @@ __m256i _mm256_slli_epi32 (__m256i a, int imm8) pure @trusted
         //       than the size of the quantity being shifted"
         //       and it's UB instead.
         int8 a_int8 = cast(int8) a;
-        int8 r = _mm256_setzero_si256();
+        int8 r      = cast(int8) _mm256_setzero_si256();
 
         ubyte count = cast(ubyte) imm8;
         if (count > 31)
-            return r;
+            return cast(__m256i) r;
 
         foreach(i; 0..8)
             r.ptr[i] = cast(uint)(a_int8.array[i]) << count;
-        return r;
+        return cast(__m256i) r;
     }
 }
 unittest
@@ -369,7 +369,7 @@ __m256i _mm256_srli_epi32 (__m256i a, int imm8) pure @trusted
         r.ptr[5] = a_int8.array[5] >>> count;
         r.ptr[6] = a_int8.array[6] >>> count;
         r.ptr[7] = a_int8.array[7] >>> count;
-        return r;
+        return cast(__m256i) r;
     }
 }
 unittest

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -60,16 +60,17 @@ __m256i _mm256_cvtepu16_epi32(__m128i a) pure @trusted
     }
     else
     {
-        ushort8 usa = cast(ushort8)a;
-        uint8 r;
-        r.ptr[0] = usa.array[0];
-        r.ptr[1] = usa.array[1];
-        r.ptr[2] = usa.array[2];
-        r.ptr[3] = usa.array[3];
-        r.ptr[4] = usa.array[4];
-        r.ptr[5] = usa.array[5];
-        r.ptr[6] = usa.array[6];
-        r.ptr[7] = usa.array[7];
+        short8 sa = cast(short8)a;
+        int8 r;
+        // Explicit cast to unsigned to get *zero* extension (instead of sign extension).
+        r.ptr[0] = cast(ushort)sa.array[0];
+        r.ptr[1] = cast(ushort)sa.array[1];
+        r.ptr[2] = cast(ushort)sa.array[2];
+        r.ptr[3] = cast(ushort)sa.array[3];
+        r.ptr[4] = cast(ushort)sa.array[4];
+        r.ptr[5] = cast(ushort)sa.array[5];
+        r.ptr[6] = cast(ushort)sa.array[6];
+        r.ptr[7] = cast(ushort)sa.array[7];
         return cast(__m256i)r;
     }
 }
@@ -100,7 +101,7 @@ __m128i _mm256_extracti128_si256(int imm8)(__m256i a) pure @trusted
     }
     else
     {
-        ulong2 ret;
+        long2 ret;
         ret.ptr[0] = (imm8==1) ? a.array[2] : a.array[0];
         ret.ptr[1] = (imm8==1) ? a.array[3] : a.array[1];
         return cast(__m128i) ret;
@@ -237,12 +238,12 @@ unittest
     __m256i A = _mm256_setr_epi16(0, 1, 2, 3, -4, -5, 6, 7, 0, 1, 2, 3, -4, -5, 6, 7);
     short16 B = cast(short16)( _mm256_slli_epi16(A, 1) );
     short16 B2 = cast(short16)( _mm256_slli_epi16(A, 1 + 256) );
-    short[8] expectedB = [ 0, 2, 4, 6, -8, -10, 12, 14, 0, 2, 4, 6, -8, -10, 12, 14 ];
+    short[16] expectedB = [ 0, 2, 4, 6, -8, -10, 12, 14, 0, 2, 4, 6, -8, -10, 12, 14 ];
     assert(B.array == expectedB);
     assert(B2.array == expectedB);
 
     short16 C = cast(short16)( _mm256_slli_epi16(A, 16) );
-    short[8] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
+    short[16] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
     assert(C.array == expectedC);
 }
 

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -253,11 +253,11 @@ __m256i _mm256_slli_epi32 (__m256i a, int imm8) pure @trusted
 {
     static if (GDC_with_AVX2)
     {
-        return __builtin_ia32_pslldi256(cast(int8)a, cast(ubyte)imm8);
+        return cast(__m256i) __builtin_ia32_pslldi256(cast(int8)a, cast(ubyte)imm8);
     }
     else static if (LDC_with_AVX2)
     {
-        return __builtin_ia32_pslldi256(cast(int8)a, cast(ubyte)imm8);
+        return cast(__m256i) __builtin_ia32_pslldi256(cast(int8)a, cast(ubyte)imm8);
     }
     else
     {
@@ -343,11 +343,11 @@ __m256i _mm256_srli_epi32 (__m256i a, int imm8) pure @trusted
 {
     static if (GDC_with_AVX2)
     {
-        return __builtin_ia32_psrldi256(cast(int8)a, cast(ubyte)imm8);
+        return cast(__m256i) __builtin_ia32_psrldi256(cast(int8)a, cast(ubyte)imm8);
     }
     else static if (LDC_with_AVX2)
     {
-        return __builtin_ia32_psrldi256(cast(int8)a, cast(ubyte)imm8);
+        return cast(__m256i) __builtin_ia32_psrldi256(cast(int8)a, cast(ubyte)imm8);
     }
     else
     {

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -110,8 +110,8 @@ __m128i _mm256_extracti128_si256(int imm8)(__m256i a) pure @trusted
 unittest
 {
     __m256i A = _mm256_setr_epi32( -7, -1, 0, 9, -100, 100, 234, 432 );
-    int[4] correct0 = [ -100, 100, 234, 432 ];
-    int[4] correct1 = [ -7, -1, 0, 9 ];
+    int[4] correct0 = [ -7, -1, 0, 9 ];
+    int[4] correct1 = [ -100, 100, 234, 432 ];
     __m128i R0 = _mm256_extracti128_si256!(0)(A);
     __m128i R1 = _mm256_extracti128_si256!(1)(A);
     assert(R0.array == correct0);

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -31,7 +31,7 @@ __m256i _mm256_add_epi32(__m256i a, __m256i b) pure @safe
 unittest
 {
     __m256i A = _mm256_setr_epi32( -7, -1, 0, 9, -100, 100, 234, 432);
-    int8 R = _mm256_add_epi32(A, A);
+    int8 R = cast(int8) _mm256_add_epi32(A, A);
     int[8] correct = [ -14, -2, 0, 18, -200, 200, 468, 864 ];
     assert(R.array == correct);
 }
@@ -46,7 +46,7 @@ unittest
 {
     __m256i A = _mm256_set1_epi32(7);
     __m256i B = _mm256_set1_epi32(14);
-    int8 R = _mm256_and_si256(A, B);
+    int8 R = cast(int8) _mm256_and_si256(A, B);
     int[8] correct = [6, 6, 6, 6, 6, 6, 6, 6];
     assert(R.array == correct);
 }
@@ -148,7 +148,7 @@ unittest
 {
     short16 A = [0, 1, 2, 3, -32768, -32768, 32767, 32767, 0, 1, 2, 3, -32768, -32768, 32767, 32767];
     short16 B = [0, 1, 2, 3, -32768, -32768, 32767, 32767, 0, 1, 2, 3, -32768, -32768, 32767, 32767];
-    int8 R = _mm256_madd_epi16(cast(__m256i)A, cast(__m256i)B);
+    int8 R = cast(int8) _mm256_madd_epi16(cast(__m256i)A, cast(__m256i)B);
     int[8] correct = [1, 13, -2147483648, 2*32767*32767, 1, 13, -2147483648, 2*32767*32767];
     assert(R.array == correct);
 }
@@ -198,7 +198,7 @@ unittest
     __m256i A = _mm256_setr_epi8(3, 4, 6, 8, 12, 14, 18, 20, 24, 30, 32, 38, 42, 44, 48, 54,
                               3, 4, 6, 8, 12, 14, 18, 20, 24, 30, 32, 38, 42, 44, 48, 54); // primes + 1
     __m256i B = _mm256_set1_epi8(1);
-    int8 R = _mm256_sad_epu8(A, B);
+    int8 R = cast(int8) _mm256_sad_epu8(A, B);
     int[8] correct = [2 + 3 + 5 + 7 + 11 + 13 + 17 + 19,
                       0,
                       23 + 29 + 31 + 37 + 41 + 43 + 47 + 53,
@@ -280,17 +280,17 @@ __m256i _mm256_slli_epi32 (__m256i a, int imm8) pure @trusted
 unittest
 {
     __m256i A = _mm256_setr_epi32(0, 2, 3, -4, 0, 2, 3, -4);
-    int8 B = _mm256_slli_epi32(A, 1);
-    int8 B2 = _mm256_slli_epi32(A, 1 + 256);
+    int8 B = cast(int8) _mm256_slli_epi32(A, 1);
+    int8 B2 = cast(int8) _mm256_slli_epi32(A, 1 + 256);
     int[8] expectedB = [ 0, 4, 6, -8, 0, 4, 6, -8 ];
     assert(B.array == expectedB);
     assert(B2.array == expectedB);
 
-    int8 C = _mm256_slli_epi32(A, 0);
+    int8 C = cast(int8) _mm256_slli_epi32(A, 0);
     int[8] expectedC = [ 0, 2, 3, -4, 0, 2, 3, -4 ];
     assert(C.array == expectedC);
 
-    int8 D = _mm256_slli_epi32(A, 65);
+    int8 D = cast(int8) _mm256_slli_epi32(A, 65);
     int[8] expectedD = [ 0, 0, 0, 0, 0, 0, 0, 0 ];
     assert(D.array == expectedD);
 }
@@ -323,17 +323,17 @@ __m256i _mm256_srli_epi16 (__m256i a, int imm8) pure @trusted
 unittest
 {
     __m256i A = _mm256_setr_epi16(0, 1, 2, 3, -4, -5, 6, 7, 0, 1, 2, 3, -4, -5, 6, 7);
-    short16 B = _mm256_srli_epi16(A, 1);
-    short16 B2 = _mm256_srli_epi16(A, 1 + 256);
+    short16 B = cast(short16) _mm256_srli_epi16(A, 1);
+    short16 B2 = cast(short16) _mm256_srli_epi16(A, 1 + 256);
     short[16] expectedB = [ 0, 0, 1, 1, 0x7FFE, 0x7FFD, 3, 3, 0, 0, 1, 1, 0x7FFE, 0x7FFD, 3, 3 ];
     assert(B.array == expectedB);
     assert(B2.array == expectedB);
 
-    short16 C = _mm256_srli_epi16(A, 16);
+    short16 C = cast(short16) _mm256_srli_epi16(A, 16);
     short[16] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
     assert(C.array == expectedC);
 
-    short16 D = _mm256_srli_epi16(A, 0);
+    short16 D = cast(short16) _mm256_srli_epi16(A, 0);
     short[16] expectedD = [ 0, 1, 2, 3, -4, -5, 6, 7, 0, 1, 2, 3, -4, -5, 6, 7 ];
     assert(D.array == expectedD);
 }
@@ -375,13 +375,13 @@ __m256i _mm256_srli_epi32 (__m256i a, int imm8) pure @trusted
 unittest
 {
     __m256i A = _mm256_setr_epi32(0, 2, 3, -4, 0, 2, 3, -4);
-    int8 B = _mm256_srli_epi32(A, 1);
-    int8 B2 = _mm256_srli_epi32(A, 1 + 256);
+    int8 B = cast(int8) _mm256_srli_epi32(A, 1);
+    int8 B2 = cast(int8) _mm256_srli_epi32(A, 1 + 256);
     int[8] expectedB = [ 0, 1, 1, 0x7FFFFFFE, 0, 1, 1, 0x7FFFFFFE];
     assert(B.array == expectedB);
     assert(B2.array == expectedB);
 
-    int8 C = _mm256_srli_epi32(A, 255);
+    int8 C = cast(int8) _mm256_srli_epi32(A, 255);
     int[8] expectedC = [ 0, 0, 0, 0, 0, 0, 0, 0 ];
     assert(C.array == expectedC);
 }

--- a/source/inteli/avx2intrin.d
+++ b/source/inteli/avx2intrin.d
@@ -253,11 +253,11 @@ __m256i _mm256_slli_epi32 (__m256i a, int imm8) pure @trusted
 {
     static if (GDC_with_AVX2)
     {
-        return __builtin_ia32_pslldi256(a, cast(ubyte)imm8);
+        return __builtin_ia32_pslldi256(cast(int8)a, cast(ubyte)imm8);
     }
     else static if (LDC_with_AVX2)
     {
-        return __builtin_ia32_pslldi256(a, cast(ubyte)imm8);
+        return __builtin_ia32_pslldi256(cast(int8)a, cast(ubyte)imm8);
     }
     else
     {
@@ -343,11 +343,11 @@ __m256i _mm256_srli_epi32 (__m256i a, int imm8) pure @trusted
 {
     static if (GDC_with_AVX2)
     {
-        return __builtin_ia32_psrldi256(a, cast(ubyte)imm8);
+        return __builtin_ia32_psrldi256(cast(int8)a, cast(ubyte)imm8);
     }
     else static if (LDC_with_AVX2)
     {
-        return __builtin_ia32_psrldi256(a, cast(ubyte)imm8);
+        return __builtin_ia32_psrldi256(cast(int8)a, cast(ubyte)imm8);
     }
     else
     {

--- a/source/inteli/avxintrin.d
+++ b/source/inteli/avxintrin.d
@@ -138,6 +138,24 @@ unittest
     assert(A.array == correct);
 }
 
+/// Set packed 16-bit integers with the supplied values in reverse order.
+__m256i _mm256_setr_epi16 (short e15, short e14, short e13, short e12, short e11, short e10, short e9,  short e8,
+                           short e7,  short e6,  short e5,  short e4,  short e3,  short e2,  short e1,  short e0) pure @trusted
+{
+    pragma(inline, true);
+    short[16] result = [ e15,  e14,  e13,  e12,  e11,  e10,  e9,   e8,
+                         e7,   e6,   e5,   e4,   e3,   e2,   e1,   e0];
+    return cast(__m256i)( loadUnaligned!(short16)(result.ptr) );
+}
+unittest
+{
+    short16 A = cast(short16) _mm256_setr_epi8(-1, 0, -21, 21, 42, 127, -42, -128,
+                                               -1, 0, -21, 21, 42, 127, -42, -128);
+    short[16] correct = [-1, 0, -21, 21, 42, 127, -42, -128,
+                         -1, 0, -21, 21, 42, 127, -42, -128];
+    assert(A.array == correct);
+}
+
 /// Set packed 32-bit integers with the supplied values in reverse order.
 __m256i _mm256_setr_epi32 (int e7, int e6, int e5, int e4, int e3, int e2, int e1, int e0) pure @trusted
 {

--- a/source/inteli/avxintrin.d
+++ b/source/inteli/avxintrin.d
@@ -47,7 +47,7 @@ __m256i _mm256_loadu_si256 (const(__m256i)* mem_addr) pure @trusted
     }
     else
     {
-        return loadUnaligned!(__m256i)(cast(int*)mem_addr);
+        return loadUnaligned!(__m256i)(cast(long*)mem_addr);
     }
 }
 unittest

--- a/source/inteli/avxintrin.d
+++ b/source/inteli/avxintrin.d
@@ -149,8 +149,8 @@ __m256i _mm256_setr_epi16 (short e15, short e14, short e13, short e12, short e11
 }
 unittest
 {
-    short16 A = cast(short16) _mm256_setr_epi8(-1, 0, -21, 21, 42, 127, -42, -128,
-                                               -1, 0, -21, 21, 42, 127, -42, -128);
+    short16 A = cast(short16) _mm256_setr_epi16(-1, 0, -21, 21, 42, 127, -42, -128,
+                                                -1, 0, -21, 21, 42, 127, -42, -128);
     short[16] correct = [-1, 0, -21, 21, 42, 127, -42, -128,
                          -1, 0, -21, 21, 42, 127, -42, -128];
     assert(A.array == correct);

--- a/source/inteli/avxintrin.d
+++ b/source/inteli/avxintrin.d
@@ -1,0 +1,164 @@
+/**
+* AVX intrinsics.
+* https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#techs=AVX
+*
+* Copyright: Guillaume Piolat 2022.
+*            Johan Engelen 2022.
+* License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+*/
+module inteli.avxintrin;
+
+// AVX instructions
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#techs=AVX
+// Note: this header will work whether you have AVX enabled or not.
+// With LDC, use "dflags-ldc": ["-mattr=+avx"] or equivalent to actively
+// generate AVX instructions.
+
+public import inteli.types;
+import inteli.internals;
+
+// Pull in all previous instruction set intrinsics.
+public import inteli.tmmintrin;
+
+nothrow @nogc:
+
+/// Extract a 32-bit integer from `a`, selected with `imm8`.
+int _mm256_extract_epi32 (__m256i a, const int imm8) pure @trusted
+{
+    return (cast(int8)a).array[imm8 & 7];
+}
+unittest
+{
+    align(16) int[8] data = [-1, 2, -3, 4, 9, -7, 8, -6];
+    auto A = _mm256_loadu_si256(cast(__m256i*) data.ptr);
+    assert(_mm256_extract_epi32(A, 0) == -1);
+    assert(_mm256_extract_epi32(A, 1 + 8) == 2);
+    assert(_mm256_extract_epi32(A, 3 + 16) == 4);
+    assert(_mm256_extract_epi32(A, 7 + 32) == -6);
+}
+
+/// Load 128-bits of integer data from memory. `mem_addr` does not need to be aligned on any particular boundary.
+__m256i _mm256_loadu_si256 (const(__m256i)* mem_addr) pure @trusted
+{
+    pragma(inline, true);
+    static if (GDC_with_AVX)
+    {
+        return cast(__m256i) __builtin_ia32_loaddqu256(cast(const(char*))mem_addr);
+    }
+    else
+    {
+        return loadUnaligned!(__m256i)(cast(int*)mem_addr);
+    }
+}
+unittest
+{
+    align(16) int[8] correct = [-1, 2, -3, 4, 9, -7, 8, -6];
+    int8 A = cast(int8) _mm256_loadu_si256(cast(__m256i*) correct.ptr);
+    assert(A.array == correct);
+}
+
+/// Broadcast 8-bit integer `a` to all elements of the return value.
+__m256i _mm256_set1_epi8 (byte a) pure @trusted
+{
+    version(DigitalMars) // workaround https://issues.dlang.org/show_bug.cgi?id=21469
+    {
+        byte32 v = a;
+        return cast(__m256i) v;
+    }
+    else
+    {
+        pragma(inline, true);
+        return cast(__m256i)(byte32(a));
+    }
+}
+unittest
+{
+    byte32 a = cast(byte32) _mm256_set1_epi8(31);
+    for (int i = 0; i < 32; ++i)
+        assert(a.array[i] == 31);
+}
+
+/// Broadcast 16-bit integer `a` to all elements of the return value.
+__m256i _mm256_set1_epi16 (short a) pure @trusted
+{
+    version(DigitalMars) // workaround https://issues.dlang.org/show_bug.cgi?id=21469
+    {
+        short16 v = a;
+        return cast(__m256i) v;
+    }
+    else
+    {
+        pragma(inline, true);
+        return cast(__m256i)(short16(a));
+    }
+}
+unittest
+{
+    short16 a = cast(short16) _mm256_set1_epi16(31);
+    for (int i = 0; i < 16; ++i)
+        assert(a.array[i] == 31);
+}
+
+/// Broadcast 32-bit integer `a` to all elements.
+__m256i _mm256_set1_epi32 (int a) pure @trusted
+{
+    pragma(inline, true);
+    return cast(__m256i)(int8(a));
+}
+unittest
+{
+    int8 a = cast(int8) _mm256_set1_epi32(31);
+    for (int i = 0; i < 8; ++i)
+        assert(a.array[i] == 31);
+}
+
+/// Set packed 8-bit integers with the supplied values in reverse order.
+__m256i _mm256_setr_epi8 (byte e31, byte e30, byte e29, byte e28, byte e27, byte e26, byte e25, byte e24,
+                          byte e23, byte e22, byte e21, byte e20, byte e19, byte e18, byte e17, byte e16,
+                          byte e15, byte e14, byte e13, byte e12, byte e11, byte e10, byte e9,  byte e8,
+                          byte e7,  byte e6,  byte e5,  byte e4,  byte e3,  byte e2,  byte e1,  byte e0) pure @trusted
+{
+    pragma(inline, true);
+    byte[32] result = [ e31,  e30,  e29,  e28,  e27,  e26,  e25,  e24,
+                        e23,  e22,  e21,  e20,  e19,  e18,  e17,  e16,
+                        e15,  e14,  e13,  e12,  e11,  e10,  e9,   e8,
+                        e7,   e6,   e5,   e4,   e3,   e2,   e1,   e0];
+    return cast(__m256i)( loadUnaligned!(byte32)(result.ptr) );
+}
+unittest
+{
+    byte32 A = cast(byte32) _mm256_setr_epi8( -1, 0, -21, 21, 42, 127, -42, -128,
+                                              -1, 0, -21, 21, 42, 127, -42, -128,
+                                              -1, 0, -21, 21, 42, 127, -42, -128,
+                                              -1, 0, -21, 21, 42, 127, -42, -128);
+    byte[32] correct = [-1, 0, -21, 21, 42, 127, -42, -128,
+                        -1, 0, -21, 21, 42, 127, -42, -128,
+                        -1, 0, -21, 21, 42, 127, -42, -128,
+                        -1, 0, -21, 21, 42, 127, -42, -128];
+    assert(A.array == correct);
+}
+
+/// Set packed 32-bit integers with the supplied values in reverse order.
+__m256i _mm256_setr_epi32 (int e7, int e6, int e5, int e4, int e3, int e2, int e1, int e0) pure @trusted
+{
+    pragma(inline, true);
+    int[8] result = [e7, e6, e5, e4, e3, e2, e1, e0];
+    return cast(__m256i)( loadUnaligned!(int8)(result.ptr) );
+}
+unittest
+{
+    int8 A = cast(int8) _mm256_setr_epi32(-1, 0, -2147483648, 2147483647, 42, 666, -42, -666);
+    int[8] correct = [-1, 0, -2147483648, 2147483647, 42, 666, -42, -666];
+    assert(A.array == correct);
+}
+
+
+/// Return vector of type `__m256i` with all elements set to zero.
+__m256i _mm256_setzero_si256() pure @trusted
+{
+    pragma(inline, true);
+    // Note: using loadUnaligned has better -O0 codegen compared to .ptr
+    int[8] result = [0, 0, 0, 0, 0, 0, 0, 0];
+    return cast(__m256i)( loadUnaligned!(int8)(result.ptr) );
+}
+

--- a/source/inteli/internals.d
+++ b/source/inteli/internals.d
@@ -30,6 +30,8 @@ version(GNU)
         enum GDC_with_SSSE3 = false;
         enum GDC_with_SSE41 = false;
         enum GDC_with_SSE42 = false;
+        enum GDC_with_AVX = false;
+        enum GDC_with_AVX2 = false;
         enum GDC_with_SHA = false;
         enum GDC_with_BMI2 = false;
     }
@@ -55,6 +57,8 @@ version(GNU)
         enum GDC_with_SSSE3 = false; // TODO: we don't have a way to detect that at CT
         enum GDC_with_SSE41 = false; // TODO: we don't have a way to detect that at CT
         enum GDC_with_SSE42 = false; // TODO: we don't have a way to detect that at CT
+        enum GDC_with_AVX = false; // TODO: we don't have a way to detect that at CT
+        enum GDC_with_AVX2 = false; // TODO: we don't have a way to detect that at CT
         enum GDC_with_SHA = false;
         enum GDC_with_BMI2 = false;
     }
@@ -68,6 +72,8 @@ version(GNU)
         enum GDC_with_SSSE3 = false;
         enum GDC_with_SSE41 = false;
         enum GDC_with_SSE42 = false;
+        enum GDC_with_AVX = false;
+        enum GDC_with_AVX2 = false;
         enum GDC_with_SHA = false;
         enum GDC_with_BMI2 = false;
     }
@@ -82,6 +88,8 @@ else
     enum GDC_with_SSSE3 = false;
     enum GDC_with_SSE41 = false;
     enum GDC_with_SSE42 = false;
+    enum GDC_with_AVX = false;
+    enum GDC_with_AVX2 = false;
     enum GDC_with_SHA = false;
     enum GDC_with_BMI2 = false;
 }

--- a/source/inteli/package.d
+++ b/source/inteli/package.d
@@ -18,6 +18,8 @@ public import inteli.smmintrin;  // SSE4.1
 public import inteli.nmmintrin;  // SSE4.2
 public import inteli.shaintrin;  // SHA
 public import inteli.bmi2intrin; // BMI2
+public import inteli.avxintrin;  // AVX
+public import inteli.avx2intrin; // AVX2
 
 public import inteli.math; // Bonus
 

--- a/source/inteli/types.d
+++ b/source/inteli/types.d
@@ -532,6 +532,9 @@ static assert(double2.sizeof == 16);
 
 
 
+alias __m256 = float8;
+alias __m256i = int8;
+alias __m256d = double4;
 alias __m128 = float4;
 alias __m128i = int4;
 alias __m128d = double2;

--- a/source/inteli/types.d
+++ b/source/inteli/types.d
@@ -48,9 +48,19 @@ version(GNU)
             return cast(byte16) __builtin_ia32_loaddqu(cast(const(char)*) pvec);
         }
 
+        byte32 loadUnaligned(Vec)(const(byte)* pvec) @trusted if (is(Vec == byte32))
+        {
+            return cast(byte32) __builtin_ia32_loaddqu256(cast(const(char)*) pvec);
+        }
+
         short8 loadUnaligned(Vec)(const(short)* pvec) @trusted if (is(Vec == short8))
         {
             return cast(short8) __builtin_ia32_loaddqu(cast(const(char)*) pvec);
+        }
+
+        short16 loadUnaligned(Vec)(const(short)* pvec) @trusted if (is(Vec == short16))
+        {
+            return cast(short16) __builtin_ia32_loaddqu256(cast(const(char)*) pvec);
         }
 
         int4 loadUnaligned(Vec)(const(int)* pvec) @trusted if (is(Vec == int4))
@@ -58,17 +68,19 @@ version(GNU)
             return cast(int4) __builtin_ia32_loaddqu(cast(const(char)*) pvec);
         }
 
+        int8 loadUnaligned(Vec)(const(int)* pvec) @trusted if (is(Vec == int8))
+        {
+            return cast(int8) __builtin_ia32_loaddqu256(cast(const(char)*) pvec);
+        }
+
         long2 loadUnaligned(Vec)(const(long)* pvec) @trusted if (is(Vec == long2))
         {
             return cast(long2) __builtin_ia32_loaddqu(cast(const(char)*) pvec);
         }
 
-        Vec loadUnaligned(Vec)(const(byte)* pvec) @trusted if ( is(Vec == byte32) ||
-                                                                is(Vec == short16) ||
-                                                                is(Vec == int8) ||
-                                                                is(Vec == long4) )
+        long4 loadUnaligned(Vec)(const(long)* pvec) @trusted if (is(Vec == long4))
         {
-            return cast(Vec) __builtin_ia32_loaddqu256(cast(const(char)*) pvec);
+            return cast(long4) __builtin_ia32_loaddqu256(cast(const(char)*) pvec);
         }
 
         void storeUnaligned(Vec)(Vec v, float* pvec) @trusted if (is(Vec == float4))
@@ -96,9 +108,19 @@ version(GNU)
             __builtin_ia32_storedqu(cast(char*)pvec, cast(ubyte16)v);
         }
 
+        void storeUnaligned(Vec)(Vec v, byte* pvec) @trusted if (is(Vec == byte32))
+        {
+            __builtin_ia32_storedqu256(cast(char*)pvec, cast(ubyte32)v);
+        }
+
         void storeUnaligned(Vec)(Vec v, short* pvec) @trusted if (is(Vec == short8))
         {
             __builtin_ia32_storedqu(cast(char*)pvec, cast(ubyte16)v);
+        }
+
+        void storeUnaligned(Vec)(Vec v, short* pvec) @trusted if (is(Vec == short16))
+        {
+            __builtin_ia32_storedqu256(cast(char*)pvec, cast(ubyte32)v);
         }
 
         void storeUnaligned(Vec)(Vec v, int* pvec) @trusted if (is(Vec == int4))
@@ -106,15 +128,17 @@ version(GNU)
             __builtin_ia32_storedqu(cast(char*)pvec, cast(ubyte16)v);
         }
 
+        void storeUnaligned(Vec)(Vec v, int* pvec) @trusted if (is(Vec == int8))
+        {
+            __builtin_ia32_storedqu256(cast(char*)pvec, cast(ubyte32)v);
+        }
+
         void storeUnaligned(Vec)(Vec v, long* pvec) @trusted if (is(Vec == long2))
         {
             __builtin_ia32_storedqu(cast(char*)pvec, cast(ubyte16)v);
         }
 
-        void storeUnaligned(Vec)(Vec v, long* pvec) @trusted if ( is(Vec == byte32) ||
-                                                                  is(Vec == short16) ||
-                                                                  is(Vec == int8) ||
-                                                                  is(Vec == long4) )
+        void storeUnaligned(Vec)(Vec v, long* pvec) @trusted if (is(Vec == long4))
         {
             __builtin_ia32_storedqu256(cast(char*)pvec, cast(ubyte32)v);
         }

--- a/source/inteli/types.d
+++ b/source/inteli/types.d
@@ -28,9 +28,19 @@ version(GNU)
             return __builtin_ia32_loadups(pvec);
         }
 
+        float8 loadUnaligned(Vec)(const(float)* pvec) @trusted if (is(Vec == float8))
+        {
+            return __builtin_ia32_loadups256(pvec);
+        }
+
         double2 loadUnaligned(Vec)(const(double)* pvec) @trusted if (is(Vec == double2))
         {
             return __builtin_ia32_loadupd(pvec);
+        }
+
+        double4 loadUnaligned(Vec)(const(double)* pvec) @trusted if (is(Vec == double4))
+        {
+            return __builtin_ia32_loadupd256(pvec);
         }
 
         byte16 loadUnaligned(Vec)(const(byte)* pvec) @trusted if (is(Vec == byte16))
@@ -53,14 +63,32 @@ version(GNU)
             return cast(long2) __builtin_ia32_loaddqu(cast(const(char)*) pvec);
         }
 
+        Vec loadUnaligned(Vec)(const(byte)* pvec) @trusted if ( is(Vec == byte32) ||
+                                                                is(Vec == short16) ||
+                                                                is(Vec == int8) ||
+                                                                is(Vec == long4) )
+        {
+            return cast(Vec) __builtin_ia32_loaddqu256(cast(const(char)*) pvec);
+        }
+
         void storeUnaligned(Vec)(Vec v, float* pvec) @trusted if (is(Vec == float4))
         {
             __builtin_ia32_storeups(pvec, v);
         }
 
+        void storeUnaligned(Vec)(Vec v, float* pvec) @trusted if (is(Vec == float8))
+        {
+            __builtin_ia32_storeups256(pvec, v);
+        }
+
         void storeUnaligned(Vec)(Vec v, double* pvec) @trusted if (is(Vec == double2))
         {
             __builtin_ia32_storeupd(pvec, v);
+        }
+
+        void storeUnaligned(Vec)(Vec v, double* pvec) @trusted if (is(Vec == double4))
+        {
+            __builtin_ia32_storeupd256(pvec, v);
         }
 
         void storeUnaligned(Vec)(Vec v, byte* pvec) @trusted if (is(Vec == byte16))
@@ -81,6 +109,14 @@ version(GNU)
         void storeUnaligned(Vec)(Vec v, long* pvec) @trusted if (is(Vec == long2))
         {
             __builtin_ia32_storedqu(cast(char*)pvec, cast(ubyte16)v);
+        }
+
+        void storeUnaligned(Vec)(Vec v, long* pvec) @trusted if ( is(Vec == byte32) ||
+                                                                  is(Vec == short16) ||
+                                                                  is(Vec == int8) ||
+                                                                  is(Vec == long4) )
+        {
+            __builtin_ia32_storedqu256(cast(char*)pvec, cast(ubyte32)v);
         }
 
         // TODO: for performance, replace that anywhere possible by a GDC intrinsic

--- a/source/inteli/types.d
+++ b/source/inteli/types.d
@@ -19,7 +19,7 @@ version(GNU)
     {
         enum MMXSizedVectorsAreEmulated = false;
         enum SSESizedVectorsAreEmulated = false;
-        enum AVXSizedVectorsAreEmulated = false;
+        enum AVXSizedVectorsAreEmulated = true; // AVX vector return without AVX enabled changes the ABI
 
         import gcc.builtins;
 
@@ -649,7 +649,7 @@ static assert(double4.sizeof == 32);
 
 
 alias __m256 = float8;
-alias __m256i = int8;
+alias __m256i = long4; // long long __vector with ICC, GCC, and clang
 alias __m256d = double4;
 alias __m128 = float4;
 alias __m128i = int4;


### PR DESCRIPTION
I ported the code from this article, http://0x80.pl/notesen/2018-10-24-sse-sumbytes.html, and needed these intrinsics.
(https://github.com/WojciechMula/toys/tree/master/sse-sumbytes/uint16_t)

Couldn't test the AVX or AVX2 paths on my machine, so let's see what the CI systems say.