### PR TITLE
Fix inout-return deprecation

### DIFF
--- a/source/inteli/types.d
+++ b/source/inteli/types.d
@@ -232,7 +232,7 @@ static if (CoreSimdIsEmulated)
                 return dest;
             }
 
-        ref inout(BaseType) opIndex(size_t i) inout pure nothrow @safe @nogc
+        ref inout(BaseType) opIndex(size_t i) inout return pure nothrow @safe @nogc
         {
             return array[i];
         }


### PR DESCRIPTION
With new DMD:
```
source/inteli/types.d(237,25): Deprecation: returning `this.array[i]` escapes a reference to parameter `this`
source/inteli/types.d(235,29):        perhaps annotate the function with `return`
```
