### PR TITLE
Improve portability via nurt, nulib and numem (optional)

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,18 @@
     "license": "BSL-1.0",
     "importPaths": ["source"],
     "sourcePaths": ["source"],
-
+    "dependencies": {
+        "nulib:stdc": {
+            "version": ">=0.2.0",
+            "optional": true,
+            "default": false
+        },
+        "nurt": {
+            "version": ">=0.1.4",
+            "optional": true,
+            "default": false
+        }
+    },
     "buildTypes": {
         "unittest-inst": {
             "buildOptions": ["unittests", "debugMode", "debugInfo"],

--- a/source/inteli/common.d
+++ b/source/inteli/common.d
@@ -1,0 +1,31 @@
+/**
+* Common definitions.
+* https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#techs=SSE
+* 
+* Copyright: Copyright Guillaume Piolat 2016-2020.
+* Copyright: Copyright Kitsunebi Games 2025.
+* License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+*/
+module inteli.common;
+
+version(Have_nurt) {
+    import numem.core.hooks : nu_malloc, nu_free, nu_memcpy;
+    public import core.internal.exception : onOutOfMemoryError;
+
+    alias malloc = nu_malloc;
+    alias free = nu_free;
+    alias memcpy = nu_memcpy;
+} else {
+    public import core.stdc.stdlib: malloc, free;
+    public import core.stdc.string: memcpy;
+    public import core.exception: onOutOfMemoryError;
+}
+
+void __warn_noop(string fname = __FUNCTION__)() {
+    pragma(msg, "Warning: ", fname, " is currently not supported, it will become a NO-OP!");
+}
+
+RetT __warn_noop_ret(RetT, string fname = __FUNCTION__)(RetT rval = RetT.init) if (!is(RetT == void)) {
+    pragma(msg, "Warning: ", fname, " is currently not supported, it will become a NO-OP!");
+    return rval;
+}

--- a/source/inteli/emmintrin.d
+++ b/source/inteli/emmintrin.d
@@ -11,6 +11,7 @@ public import inteli.types;
 public import inteli.xmmintrin; // SSE2 includes SSE1
 import inteli.mmx;
 import inteli.internals;
+import inteli.common;
 
 nothrow @nogc:
 
@@ -1944,8 +1945,7 @@ void _mm_lfence() @trusted
                 "lfence;\n" : : : ;
             }
         }
-        else
-            static assert(false);
+        else __warn_noop();
     }
     else static if (LDC_with_SSE2)
     {
@@ -2512,8 +2512,7 @@ void _mm_mfence() @trusted // not pure!
                 "mfence;\n" : : : ;
             }
         }
-        else
-            static assert(false);
+        else __warn_noop();
     }
     else static if (LDC_with_SSE2)
     {
@@ -3229,8 +3228,7 @@ void _mm_pause() @trusted
                 "pause;\n" : : : ;
             }
         }
-        else
-            static assert(false);
+        else __warn_noop();
     }
     else static if (LDC_with_SSE2)
     {

--- a/source/inteli/internals.d
+++ b/source/inteli/internals.d
@@ -466,10 +466,15 @@ int convertFloatToInt32UsingMXCSR(float value) @trusted
     int result;
     version(GNU)
     {
-        asm pure nothrow @nogc @trusted
+        version(X86)
         {
-            "cvtss2si %1, %0\n": "=r"(result) : "x" (value);
+            asm pure nothrow @nogc @trusted
+            {
+                "cvtss2si %1, %0\n": "=r"(result) : "x" (value);
+            }
         }
+        else
+            result = cast(int)value;
     }
     else static if (LDC_with_ARM32)
     {
@@ -507,10 +512,15 @@ int convertDoubleToInt32UsingMXCSR(double value) @trusted
     int result;
     version(GNU)
     {
-        asm pure nothrow @nogc @trusted
+        version(X86)
         {
-            "cvtsd2si %1, %0\n": "=r"(result) : "x" (value);
+            asm pure nothrow @nogc @trusted
+            {
+                "cvtsd2si %1, %0\n": "=r"(result) : "x" (value);
+            }
         }
+        else
+            result = cast(int)value;
     }
     else static if (LDC_with_ARM32)
     {
@@ -674,7 +684,7 @@ long convertFloatToInt64UsingMXCSR(float value) @trusted
             static assert(false);
     }
     else
-        static assert(false);
+        return cast(long)value;
 }
 
 
@@ -804,7 +814,7 @@ long convertDoubleToInt64UsingMXCSR(double value) @trusted
         }
     }
     else
-        static assert(false);
+        return cast(long)value;
 }
 
 //

--- a/source/inteli/xmmintrin.d
+++ b/source/inteli/xmmintrin.d
@@ -10,13 +10,10 @@ module inteli.xmmintrin;
 public import inteli.types;
 
 import inteli.internals;
+import inteli.common;
 
 import inteli.mmx;
 import inteli.emmintrin;
-
-import core.stdc.stdlib: malloc, free;
-import core.stdc.string: memcpy;
-import core.exception: onOutOfMemoryError;
 
 version(D_InlineAsm_X86)
     version = InlineX86Asm;
@@ -1265,8 +1262,7 @@ uint _mm_getcsr() @trusted
             }
             return sseRounding;
         }
-        else
-            static assert(false);
+        else return __warn_noop_ret!uint();
     }
     else version (InlineX86Asm)
     {
@@ -2455,8 +2451,7 @@ void _mm_setcsr(uint controlWord) @trusted
                   : ;
             }
         }
-        else
-            static assert(false);
+        else return __warn_noop();
     }
     else version (InlineX86Asm)
     {
@@ -2547,8 +2542,7 @@ void _mm_sfence() @trusted
                 "sfence;\n" : : : ;
             }
         }
-        else
-            static assert(false);
+        else return __warn_noop();
     }
     else static if (LDC_with_SSE)
     {


### PR DESCRIPTION
This PR adds optional support for numem, nurt and nulib.
Additionally it adds a new construct which allows compiling some SIMD actions as NO-OPs w/ compile time warnings.