### PR TITLE
Update nurt to latest version

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,12 +7,12 @@
     "sourcePaths": ["source"],
     "dependencies": {
         "nulib:stdc": {
-            "version": ">=0.2.0",
+            "version": ">=0.3.0",
             "optional": true,
             "default": false
         },
         "nurt": {
-            "version": ">=0.1.4",
+            "version": ">=0.2.2",
             "optional": true,
             "default": false
         }

--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
             "default": false
         },
         "nurt": {
-            "version": ">=0.2.2",
+            "version": ">=0.2.1",
             "optional": true,
             "default": false
         }

--- a/source/inteli/internals.d
+++ b/source/inteli/internals.d
@@ -16,7 +16,7 @@ nothrow:
 
 // nurt compatibility
 
-version(Have_nurt) 
+version(USE_NURT) 
 {
     import numem.core.hooks : nu_malloc, nu_free, nu_memcpy;
     public import core.internal.exception : onOutOfMemoryError;


### PR DESCRIPTION
Latest NuRT uses a new `USE_NURT` compile tag so that you can enable or disable nurt using a subconfiguration.

This will fail building on D frontends older than 2.106 and older than LDC 1.40.0